### PR TITLE
Infrastructure cleanups

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -4,26 +4,16 @@
 
 #include "assert.h"
 #include "io.h"
+#include "uiHelpers.h"
 
-// For debugging.
-// TODO(ppershing): PROD build
-// should mask this under a generic error
-
-void checkOrFail(int cond, const char* msg)
+// Note(ppershing): Right now suitable for debugging only.
+// We need to keep going because rendering on display
+// takes multiple SEPROXYHAL exchanges until it renders
+// the display
+void assert(int cond, const char* msg)
 {
 	if (cond) return; // everything holds
 
-	STATIC_ASSERT(sizeof(G_io_apdu_buffer) > 2, __bad_apdu_buffer_size);
-
-	// Note: we need to restrict len so that we don't get into
-	// an assert cycle (io_send_buf asserts on buf size)
-	size_t len = MIN(
-	                     sizeof(G_io_apdu_buffer) - 2,
-	                     strlen(msg)
-	             );
-
-	io_send_buf(SW_ASSERT, msg, len);
-	while (1) {
-		// halt
-	}
+	displayConfirm("Assertion failed", msg, NULL, NULL);
+	THROW(SW_ASSERT);
 }

--- a/src/assert.h
+++ b/src/assert.h
@@ -6,11 +6,10 @@
 
 #define STATIC_ASSERT(COND,MSG) typedef char static_assert__##MSG[(COND)?1:-1] __attribute__((unused))
 
+extern void assert(int cond, const char* msg);
 
-// use different name to avoid potential
-// naming conflicts with assert
-extern void checkOrFail(int cond, const char* msg);
-
-#define CHECK_OR_FAIL(cond, msg) checkOrFail(cond, msg)
+// Note(ppershing): I like macro-like uppercase version better
+// because it captures reader's attention.
+#define ASSERT(cond, msg) assert(cond, msg)
 
 #endif

--- a/src/getVersion.c
+++ b/src/getVersion.c
@@ -8,6 +8,7 @@
 #include "getPubKey.h"
 #include "errors.h"
 #include "io.h"
+#include "assert.h"
 
 // handleGetVersion is the entry point for the getVersion command. It
 // unconditionally sends the app version.
@@ -15,9 +16,7 @@ void handleGetVersion(
         uint8_t p1,
         uint8_t p2,
         uint8_t *dataBuffer,
-        uint16_t dataLength,
-        volatile unsigned int *flags,
-        volatile unsigned int *tx)
+        uint16_t dataLength)
 {
 	uint8_t response[3];
 	response[0] = APPVERSION[0] - '0';
@@ -29,30 +28,41 @@ void handleGetVersion(
 
 void handleShowAboutConfirm()
 {
+	ASSERT(0, "demo assert");
 	// send response
 	io_send_buf(SW_OK, NULL, 0);
 	ui_idle();
+}
+
+void handleShowAboutReject()
+{
+	io_send_buf(4747, NULL, 0);
+	ui_idle();
+}
+
+void handleScrollConfirm()
+{
+	displayConfirm(
+	        "Confirm",
+	        "something",
+	        handleShowAboutConfirm,
+	        handleShowAboutReject
+	);
+
 }
 
 void handleShowAbout(
         uint8_t p1,
         uint8_t p2,
         uint8_t *dataBuffer,
-        uint16_t dataLength,
-        volatile unsigned int *flags,
-        volatile unsigned int *tx)
+        uint16_t dataLength)
 {
 
 	const char* header = "Header line";
 	const char* text = "This should be a long scrolling text";
 	displayScrollingText(
-	        header, strlen(header),
-	        text, strlen(text),
-	        &handleShowAboutConfirm
+	        header,
+	        text,
+	        &handleScrollConfirm
 	);
-
-	// Set the IO_ASYNC_REPLY flag. This flag tells sia_main that we aren't
-	// sending data to the computer immediately; we need to wait for a button
-	// press first.
-	*flags |= IO_ASYNCH_REPLY;
 }

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -10,10 +10,7 @@ typedef void handler_fn_t(
         uint8_t p1,
         uint8_t p2,
         uint8_t *dataBuffer,
-        uint16_t dataLength,
-        // out
-        volatile unsigned int *flags,
-        volatile unsigned int *tx
+        uint16_t dataLength
 );
 
 handler_fn_t* lookupHandler(uint8_t ins);

--- a/src/io.c
+++ b/src/io.c
@@ -6,15 +6,15 @@
 void CHECK_RESPONSE_SIZE(unsigned int tx)
 {
 	// Note(ppershing): we do both checks due to potential overflows
-	CHECK_OR_FAIL(tx < sizeof(G_io_apdu_buffer), "response overflow");
-	CHECK_OR_FAIL(tx + 2u < sizeof(G_io_apdu_buffer), "response overflow");
+	ASSERT(tx < sizeof(G_io_apdu_buffer), "response overflow");
+	ASSERT(tx + 2u < sizeof(G_io_apdu_buffer), "response overflow");
 }
 
 // io_exchange_with_code is a helper function for sending response APDUs from
 // button handlers. Note that the IO_RETURN_AFTER_TX flag is set. 'tx' is the
 // conventional name for the size of the response APDU, i.e. the write-offset
 // within G_io_apdu_buffer.
-void io_send_code(uint16_t code, uint16_t tx)
+void _io_send_G_io_apdu_buffer(uint16_t code, uint16_t tx)
 {
 	CHECK_RESPONSE_SIZE(tx);
 	G_io_apdu_buffer[tx++] = code >> 8;
@@ -27,9 +27,7 @@ void io_send_buf(uint16_t code, uint8_t* buffer, uint16_t len)
 	CHECK_RESPONSE_SIZE(len);
 
 	os_memmove(G_io_apdu_buffer, buffer, len);
-	G_io_apdu_buffer[len++] = code >> 8;
-	G_io_apdu_buffer[len++] = code & 0xFF;
-	io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, len);
+	_io_send_G_io_apdu_buffer(code, len);
 }
 
 

--- a/src/io.h
+++ b/src/io.h
@@ -10,8 +10,9 @@
 // 'tx' is the conventional name for the size of the response APDU,
 // i.e. the write-offset within G_io_apdu_buffer.
 
-void io_send_code(uint16_t code, uint16_t tx);
+void _io_send_G_io_apdu_buffer(uint16_t code, uint16_t tx);
 
+// Normal code should use just this helper function
 void io_send_buf(uint16_t code, uint8_t* buffer, uint16_t len);
 
 // Asserts that the response fits into response buffer

--- a/src/uiHelpers.h
+++ b/src/uiHelpers.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-typedef void confirm_cb_t();
+typedef void callback_t();
 
 #define DISPLAY_TEXT_LEN 16
 #define MAX_TEXT_LEN 200
@@ -13,12 +13,34 @@ typedef struct {
 	uint8_t currentText[DISPLAY_TEXT_LEN + 1];
 	uint8_t fullText[MAX_TEXT_LEN];
 	uint16_t scrollIndex;
-	confirm_cb_t *callback;
+	callback_t *callback;
+} scrollingState_t;
+
+typedef struct {
+	uint8_t header[DISPLAY_TEXT_LEN + 1];
+	uint8_t text[DISPLAY_TEXT_LEN + 1];
+	callback_t *confirm;
+	callback_t *reject;
+} confirmState_t;
+
+typedef union {
+	scrollingState_t scrolling;
+	confirmState_t confirm;
 } displayState_t;
 
+
+void ui_idle(void);
+
 void displayScrollingText(
-        char* header, uint16_t header_len,
-        char* text, uint16_t text_len,
-        confirm_cb_t* callback);
+        const char* header,
+        const char* text,
+        callback_t* callback);
+
+void displayConfirm(
+        const char* header,
+        const char* text,
+        callback_t* confirm,
+        callback_t* reject
+);
 
 #endif


### PR DESCRIPTION
- rename checkOrFail to assert
- cleanup response functions
- make default for the main loop to *not* send response, only wait for event
- add displayConfirm UI screen