### PR TITLE
Fix uninitialized ptr in keyDerivation.c

### DIFF
--- a/src/keyDerivation.c
+++ b/src/keyDerivation.c
@@ -229,7 +229,7 @@ size_t cborEncodePubkeyAddress(
 	// this way but in the future we might need to refactor this code
 	const uint64_t INNER_SIZE= 33;
 	BUF_PTR_APPEND_TOKEN(ptr, end, CBOR_TYPE_BYTES, INNER_SIZE);
-	uint8_t* innerPtr;
+	uint8_t* innerPtr = ptr;
 	size_t innerSize = cborEncodePubkeyAddressInner(
 	                           addressRoot, addressRootSize,
 	                           ptr, end - ptr


### PR DESCRIPTION
I have no idea how this could have eluded us (and why it does not produce a compiler warning)